### PR TITLE
Change macOS runner to best available version for all

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ssh:
-    runs-on: macos-11.0
+    runs-on: macos-latest
 
     steps:
     - name: Checkout

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ssh:
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Update virtual environment to `macos-latest` cause mac os 11 is apparently preview only and new users can't use and you'll get error runner environment macos11 not found